### PR TITLE
delete --smallfiles from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./db/data:/data/db
     ports:
       - 27017:27017
-    command: mongod --bind_ip_all --smallfiles --logpath=/dev/null # --quiet
+    command: mongod --bind_ip_all --logpath=/dev/null # --quiet
 
   web:
     build: .


### PR DESCRIPTION
In Mongo 4.2 the --smallfiles mongod command line option is removed 
see: https://github.com/jsbroks/coco-annotator/issues/238